### PR TITLE
Fewer rhymebrain calls

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -154,8 +154,8 @@ function showRhymesOnly() {
 function analyzeWords() {
   // We'll do this until we get to the last term
   if (index < words.length) {
-    // Only look for rhymes if it's a word, not a space
-    if (!/\W+/.test(words[index])) {
+    // Only look for rhymes if it's a word, not a space or empty string
+    if (!/\W+/.test(words[index]) && !(words[index] === "")) {
       // Start an async request with an anonymous callback
       httpGetAsync('http://rhymebrain.com/talk?function=getRhymes&word=' + words[index],function(data){
         span = createSpan(words[index]);

--- a/sketch.js
+++ b/sketch.js
@@ -149,6 +149,26 @@ function showRhymesOnly() {
   }
 }
 
+function findGroup(cRhymes, wColor) {
+  var foundGroup = false;
+  // Going backwards, loop through all groups
+  for (var j = groups.length-1; j >= 0; j--) {
+    var group = groups[j];
+    if (cRhymes.indexOf(group[0]) != -1) {
+      // It rhymed, put it in that group and use that color
+      foundGroup = true;
+      groups[j].push(words[index]);
+      wColor = colors[j];
+    }
+  }
+  if (!foundGroup) {
+    // We didn't find any rhymes, make it its own group and own color
+    usecolor = bcolor;
+    groups.push([words[index]])
+    colors.push(wColor);
+  }
+}
+
 // Goes through each term, waiting for the previous to be finished
 function analyzeWords() {
   // We'll do this until we get to the last term
@@ -169,25 +189,8 @@ function analyzeWords() {
         cRhymes.push(words[index]);
         rhymes.push(cRhymes);
 
-        var foundGroup = false;
         var wColor = color(random(100,240), random(100,240), random(100,240));
-
-        // Going backwards, loop through all groups
-        for (var j = groups.length-1; j >= 0; j--) {
-          var group = groups[j];
-          if (cRhymes.indexOf(group[0]) != -1) {
-            // It rhymed, put it in that group and use that color
-            foundGroup = true;
-            groups[j].push(words[index]);
-            wColor = colors[j];
-          }
-        }
-        if (!foundGroup) {
-          // We didn't find any rhymes, make it its own group and own color
-          usecolor = bcolor;
-          groups.push([words[index]])
-          colors.push(wColor);
-        }
+        findGroup(cRhymes, wColor);
         // Make background color
         span.style('background-color', wColor);
         // Go to next word and do it again

--- a/sketch.js
+++ b/sketch.js
@@ -108,7 +108,6 @@ function replaceDiacritics(str) {
 
 // Setting up the page
 function setup() {
-  console.log(this);
   noCanvas();
   textfield = select("#input");
   output = select('#output');

--- a/sketch.js
+++ b/sketch.js
@@ -5,6 +5,7 @@ var words; // An array to store all words to analyze
 var rhymes = []; // Stores all of the words' rhymes (not really used)
 var groups = []; // Stores the words in groups based on their rhyme
 var colors = []; // The colors that words will be (coorespond to the groups)
+var rhymingWordLists = []; // Stores all the rhymes that come back from RhymeBrain
 var bcolor;
 var index = 0; // The current word we're looking at
 


### PR DESCRIPTION
I made a few updates to this script while I was working with it, to avoid getting rate-limited as frequently by RhymeBrain. Feel free to merge the changes in if you think it would be useful!

Some notes:

- I added a new variable `rhymingWordLists` because I didn't want to change the meaning of `rhymes` in case you were intending it to be used for something later
- I moved the group finding behavior into its own function to make it easier for me to isolate the call to RhymeBrain
- I removed out a stray console.log along my way
